### PR TITLE
add kms policy to kms and subnet id names to rds

### DIFF
--- a/aws-kms/main.tf
+++ b/aws-kms/main.tf
@@ -242,6 +242,25 @@ data "aws_iam_policy_document" "this" {
       }
     }
   }
+
+  dynamic "statement" {
+  for_each = length(var.key_services) > 0 ? [1] : []
+  content {
+    sid = "KeyService"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*",
+    ]
+    resources = ["*"]
+    principals {
+      type        = "Service"
+      identifiers = var.key_services
+    }
+    }
+  }
 }
 
 ################################################################################

--- a/aws-kms/variables.tf
+++ b/aws-kms/variables.tf
@@ -140,6 +140,12 @@ variable "key_asymmetric_sign_verify_users" {
   default     = []
 }
 
+variable "key_services" {
+  description = "A list of IAM ARNs for service accounts"
+  type        = list(string)
+  default     = []
+}
+
 variable "source_policy_documents" {
   description = "List of IAM policy documents that are merged together into the exported document. Statements must have unique `sid`s"
   type        = list(string)

--- a/aws-rds-aurora/variables.tf
+++ b/aws-rds-aurora/variables.tf
@@ -54,6 +54,12 @@ variable "network_type" {
   default     = null
 }
 
+variable "subnet_id_names" {
+  description = "name of subnet ID's"
+  type = string
+  default = "*"
+}
+
 ################################################################################
 # Cluster
 ################################################################################
@@ -666,4 +672,10 @@ variable "db_parameter_group_parameters" {
 variable "kms_key_id" {
   description = "The key ID of the KMS key"
   default = null
+}
+
+variable "kms_multi_region" {
+  description = "Determine whether the KMS key is multi region support"
+  type = bool
+  default = false
 }


### PR DESCRIPTION
3 changes have been made.

1 - A new policy has been added to the kms module. (Needed when creating aurora global db.)
2 - To specify subnet group according to name pattern while selecting subnet group in aurora rds module
Added private_subnets_with_database_tag data.
3- If kms key id is selected while creating aurora rds db, this key can be multi_region feature
has been added. (false by default)