### PR TITLE
update aws-msk modules to sasl_scram auth and public access

### DIFF
--- a/aws-msk-apache-kafka-cluster-master/outputs.tf
+++ b/aws-msk-apache-kafka-cluster-master/outputs.tf
@@ -52,3 +52,8 @@ output "cluster_name" {
   description = "MSK Cluster name"
   value       = join("", aws_msk_cluster.default.*.cluster_name)
 }
+
+output "bootstrap_brokers_public_sasl_scram" {
+  value       = one(aws_msk_cluster.default[*].bootstrap_brokers_public_sasl_scram)
+  description = "Comma separated list of one or more DNS names (or IP addresses) and SASL SCRAM port pairs for public access to the Kafka cluster using SASL/SCRAM"
+}

--- a/aws-msk-apache-kafka-cluster-master/variables.tf
+++ b/aws-msk-apache-kafka-cluster-master/variables.tf
@@ -44,10 +44,16 @@ variable "vpc_id" {
 variable "subnet_ids" {
   type        = list(string)
   description = "Subnet IDs for Client Broker"
-#  validation {
-#    condition     = length(var.subnet_ids) > 0
-#    error_message = "The subnet_ids list must have at atleast 1 value."
-#  }
+  validation {
+    condition     = length(var.subnet_ids) > 0
+    error_message = "The subnet_ids list must have at atleast 1 value."
+  }
+}
+
+variable "subnet_id_names" {
+  description = "name of subnet ID's"
+  type = string
+  default = "*"
 }
 
 # Intentionally not deprecated via security_group_inputs.tf since it cannot effectively be replaced via var.additional_security_group_rules.
@@ -213,4 +219,17 @@ variable "tags" {
   type        = map(string)
   default     = {}
   description = "tags for the MSK cluster"
+}
+
+variable "public_access_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable public access to MSK cluster (given that all of the requirements are met)"
+  nullable    = false
+}
+
+variable "secret_name" {
+  type        = string
+  default     = "AmazonMSK_credential"
+  description = "AWS Secret Manager Secret name for MSK client_sasl_scram auth method."
 }


### PR DESCRIPTION
Updates and changes in this PR:

- add secret manager resources to client_sasl_scram auth. 
- add public access option to get posibble public access.
- update subnet-id variable to make filter by subnet name tag.
- bootstrap_brokers_public_sasl_scram output added for public access.