### PR TITLE
feat(aws-eks-addons): add istio, alb routing for istio

### DIFF
--- a/aws-eks-addons/outputs.tf
+++ b/aws-eks-addons/outputs.tf
@@ -10,5 +10,5 @@ output "appliedEKSCluster" {
 
 output "load_balancer_hostname" {
   description = "Load balancer Hostname"
-  value = kubernetes_ingress_v1.alb_ingress_connect_nginx.status.0.load_balancer.0.ingress.0.hostname
+  value = kubernetes_ingress_v1.alb_ingress_connect_nginx.0.status.0.load_balancer.0.ingress.0.hostname
 }

--- a/aws-eks-addons/variables.tf
+++ b/aws-eks-addons/variables.tf
@@ -162,3 +162,15 @@ variable "rancher_hostname" {
   description = "Rancher Hostname"
   type = string
 }
+
+variable "deploy_rancher_istio" {
+  description = "Deploy Ranchers' flavor of Istio flag"
+  type        = bool
+  default     = false
+}
+
+variable "connect_alb_to_istio" {
+  description = "Setup an ALB Ingress to connect public ALB to Istio"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Refactored argocd_bootstrapper_application to use yamlencode()