### PR TITLE
feat(aws-eks-addons)!: alb to nginx and istio connections

### DIFF
--- a/aws-eks-addons/variables.tf
+++ b/aws-eks-addons/variables.tf
@@ -95,24 +95,8 @@ variable "assume_role_arn" {
   type        = string
 }
 
-variable "resful_alb_hostname" {
-  description = "REST alb hostname"
-  type        = string
-}
-
-variable "grpc_alb_hostname" {
-  description = "GRPC alb hostname"
-  type        = string
-}
-
 variable "deploy_aws_loadbalancer" {
   description = "Deploy AWS Loadbalancer flag"
-  type        = bool
-  default     = false
-}
-
-variable "deploy_ingress_nginx_resources" {
-  description = "Deploy Ingress Nginx resources"
   type        = bool
   default     = false
 }
@@ -169,8 +153,20 @@ variable "deploy_rancher_istio" {
   default     = false
 }
 
-variable "connect_alb_to_istio" {
-  description = "Setup an ALB Ingress to connect public ALB to Istio"
-  type        = bool
-  default     = false
+variable "connect_hostnames_from_alb_ing_prefix" {
+  description = "Prefix to give ingress names when connecting alb hostnames"
+  type = string
+  default = "ing-{servicename}"
+}
+
+variable "connect_hostnames_from_alb_to_nginx" {
+  description = "Incoming ALB connections with the matching hostnames will be handled internally by nginx"
+  type        = list(string)
+  default     = []
+}
+
+variable "connect_hostnames_from_alb_to_istio" {
+  description = "Incoming ALB connections with the matching hostnames will be handled internally by istio"
+  type        = list(string)
+  default     = []
 }


### PR DESCRIPTION
BREAKING CHANGES:
- variable "resful_alb_hostname" removed
- variable "grpc_alb_hostname" removed
- variable "deploy_nginx_ingress_resources" removed
- variable group "connect_hostnames_from_alb_..." added
- ingress resource for gRPC enabled ArgoCD ingress (requires further development)

With these changes any hostname hitting alb can be forwarded
to nginx, istio, or none of them. Removed variables were mostly argocd specific, 
and now can be inferred from a combination of other variables.