### PR TITLE
fix(addons): incorrect rancher hostname nesting

### DIFF
--- a/aws-eks-addons/main.tf
+++ b/aws-eks-addons/main.tf
@@ -413,9 +413,7 @@ resource "kubectl_manifest" "argocd_bootstrapper_application" {
             rancher: {
               enable: var.deploy_rancher
               values: {
-                hostname: {
-                  value: var.rancher_hostname
-                }
+                hostname: var.rancher_hostname
               }
             }
             rancherMonitoringCrd: {


### PR DESCRIPTION
This was previously fixed but the change seems to have been squashed by something else