### PR TITLE
fix irsa alb policy and eks-addon module

### DIFF
--- a/aws-eks-addons/main.tf
+++ b/aws-eks-addons/main.tf
@@ -36,6 +36,7 @@ resource "helm_release" "aws_lb_controller" {
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-load-balancer-controller"
   namespace  = "kube-system"
+  version    = "1.6.1"
   depends_on = [
     kubernetes_service_account.service-account
   ]

--- a/aws-eks-addons/variables.tf
+++ b/aws-eks-addons/variables.tf
@@ -145,7 +145,7 @@ variable "deploy_rancher_istio" {
 variable "connect_hostnames_from_alb_ing_prefix" {
   description = "Prefix to give ingress names when connecting alb hostnames"
   type = string
-  default = "ing-{servicename}"
+  default = "ing-servicename"
 }
 
 variable "connect_hostnames_from_alb_to_nginx" {

--- a/aws-iam/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/aws-iam/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -651,6 +651,7 @@ data "aws_iam_policy_document" "load_balancer_controller" {
       "elasticloadbalancing:DescribeTargetGroupAttributes",
       "elasticloadbalancing:DescribeTargetHealth",
       "elasticloadbalancing:DescribeTags",
+      "elasticloadbalancing:AddTags",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
changes:
- fix irsa alb policy to resolve aws load balancer controller "elasticloadbalancing:AddTags" permissinon error. 
- add aws-load-balancer-controller version parameter for helm deploy
- fix eks-addon variable default value