### PR TITLE
add ignore changes for argocd_bootstrapper_application

### DIFF
--- a/aws-eks-addons/main.tf
+++ b/aws-eks-addons/main.tf
@@ -508,6 +508,9 @@ resource "kubectl_manifest" "argocd_bootstrapper_application" {
     }
   })
   depends_on = [helm_release.argocd]
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 


### PR DESCRIPTION
if you want to update argocd eks bootsrapper application values or enable/disable the application, 
this can't be changed or controlled by terraform code. 

Application side changes can be applied on argocd or platform-bootsrapper repos. So this changes get control from terraform to delegate this responsibility argocd or platform-bootstarpper repos.