### PR TITLE
chore: pull in upstream changes for aws-kms

### DIFF
--- a/aws-kms/main.tf
+++ b/aws-kms/main.tf
@@ -1,15 +1,26 @@
-data "aws_partition" "current" {}
-data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {
+  count = var.create ? 1 : 0
+}
+data "aws_caller_identity" "current" {
+  count = var.create ? 1 : 0
+}
+
+locals {
+  account_id = try(data.aws_caller_identity.current[0].account_id, "")
+  partition  = try(data.aws_partition.current[0].partition, "")
+  dns_suffix = try(data.aws_partition.current[0].dns_suffix, "")
+}
 
 ################################################################################
 # Key
 ################################################################################
 
 resource "aws_kms_key" "this" {
-  count = var.create && !var.create_external ? 1 : 0
+  count = var.create && !var.create_external && !var.create_replica && !var.create_replica_external ? 1 : 0
 
   bypass_policy_lockout_safety_check = var.bypass_policy_lockout_safety_check
   customer_master_key_spec           = var.customer_master_key_spec
+  custom_key_store_id                = var.custom_key_store_id
   deletion_window_in_days            = var.deletion_window_in_days
   description                        = var.description
   enable_key_rotation                = var.enable_key_rotation
@@ -21,21 +32,21 @@ resource "aws_kms_key" "this" {
   tags = var.tags
 }
 
-
-# for public key output
+################################################################################
+# Public Key
+################################################################################
 
 data "aws_kms_public_key" "by_id" {
-  count = var.create && !var.create_external && var.create_public_key ? 1 : 0
-  key_id = "${aws_kms_key.this[0].id}"
+  count  = var.create && !var.create_external && var.create_public_key ? 1 : 0
+  key_id = aws_kms_key.this[0].id
 }
-
 
 ################################################################################
 # External Key
 ################################################################################
 
 resource "aws_kms_external_key" "this" {
-  count = var.create && var.create_external ? 1 : 0
+  count = var.create && var.create_external && !var.create_replica && !var.create_replica_external ? 1 : 0
 
   bypass_policy_lockout_safety_check = var.bypass_policy_lockout_safety_check
   deletion_window_in_days            = var.deletion_window_in_days
@@ -44,6 +55,42 @@ resource "aws_kms_external_key" "this" {
   key_material_base64                = var.key_material_base64
   multi_region                       = var.multi_region
   policy                             = coalesce(var.policy, data.aws_iam_policy_document.this[0].json)
+  valid_to                           = var.valid_to
+
+  tags = var.tags
+}
+
+################################################################################
+# Replica Key
+################################################################################
+
+resource "aws_kms_replica_key" "this" {
+  count = var.create && var.create_replica && !var.create_external && !var.create_replica_external ? 1 : 0
+
+  bypass_policy_lockout_safety_check = var.bypass_policy_lockout_safety_check
+  deletion_window_in_days            = var.deletion_window_in_days
+  description                        = var.description
+  primary_key_arn                    = var.primary_key_arn
+  enabled                            = var.is_enabled
+  policy                             = coalesce(var.policy, data.aws_iam_policy_document.this[0].json)
+
+  tags = var.tags
+}
+
+################################################################################
+# Replica External Key
+################################################################################
+
+resource "aws_kms_replica_external_key" "this" {
+  count = var.create && !var.create_replica && !var.create_external && var.create_replica_external ? 1 : 0
+
+  bypass_policy_lockout_safety_check = var.bypass_policy_lockout_safety_check
+  deletion_window_in_days            = var.deletion_window_in_days
+  description                        = var.description
+  enabled                            = var.is_enabled
+  key_material_base64                = var.key_material_base64
+  policy                             = coalesce(var.policy, data.aws_iam_policy_document.this[0].json)
+  primary_key_arn                    = var.primary_external_key_arn
   valid_to                           = var.valid_to
 
   tags = var.tags
@@ -70,7 +117,7 @@ data "aws_iam_policy_document" "this" {
 
       principals {
         type        = "AWS"
-        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"]
+        identifiers = ["arn:${local.partition}:iam::${local.account_id}:root"]
       }
     }
   }
@@ -112,6 +159,8 @@ data "aws_iam_policy_document" "this" {
         "kms:UntagResource",
         "kms:ScheduleKeyDeletion",
         "kms:CancelKeyDeletion",
+        "kms:ReplicateKey",
+        "kms:ImportKeyMaterial"
       ]
       resources = ["*"]
 
@@ -160,6 +209,51 @@ data "aws_iam_policy_document" "this" {
       principals {
         type        = "AWS"
         identifiers = var.key_service_users
+      }
+
+      condition {
+        test     = "Bool"
+        variable = "kms:GrantIsForAWSResource"
+        values   = [true]
+      }
+    }
+  }
+
+  # Key service roles for autoscaling - https://docs.aws.amazon.com/autoscaling/ec2/userguide/key-policy-requirements-EBS-encryption.html#policy-example-cmk-access
+  dynamic "statement" {
+    for_each = length(var.key_service_roles_for_autoscaling) > 0 ? [1] : []
+
+    content {
+      sid = "KeyServiceRolesASG"
+      actions = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      resources = ["*"]
+
+      principals {
+        type        = "AWS"
+        identifiers = var.key_service_roles_for_autoscaling
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = length(var.key_service_roles_for_autoscaling) > 0 ? [1] : []
+
+    content {
+      sid = "KeyServiceRolesASGPersistentVol"
+      actions = [
+        "kms:CreateGrant"
+      ]
+      resources = ["*"]
+
+      principals {
+        type        = "AWS"
+        identifiers = var.key_service_roles_for_autoscaling
       }
 
       condition {
@@ -252,22 +346,125 @@ data "aws_iam_policy_document" "this" {
     }
   }
 
+  # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/access-control-managing-permissions.html#KMS-key-policy-for-DNSSEC
   dynamic "statement" {
-  for_each = length(var.key_services) > 0 ? [1] : []
-  content {
-    sid = "KeyService"
-    actions = [
-      "kms:Decrypt",
-      "kms:DescribeKey",
-      "kms:Encrypt",
-      "kms:GenerateDataKey*",
-      "kms:ReEncrypt*",
-    ]
-    resources = ["*"]
-    principals {
-      type        = "Service"
-      identifiers = var.key_services
+    for_each = var.enable_route53_dnssec ? [1] : []
+
+    content {
+      sid = "Route53DnssecService"
+      actions = [
+        "kms:DescribeKey",
+        "kms:GetPublicKey",
+        "kms:Sign",
+      ]
+      resources = ["*"]
+
+      principals {
+        type        = "Service"
+        identifiers = ["dnssec-route53.${local.dns_suffix}"]
+      }
     }
+  }
+
+  dynamic "statement" {
+    for_each = length(var.key_services) > 0 ? [1] : []
+    content {
+      sid = "KeyService"
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*",
+      ]
+      resources = ["*"]
+      principals {
+        type        = "Service"
+        identifiers = var.key_services
+      }
+    }
+  }
+
+  # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/access-control-managing-permissions.html#KMS-key-policy-for-DNSSEC
+  dynamic "statement" {
+    for_each = var.enable_route53_dnssec ? [1] : []
+
+    content {
+      sid       = "Route53DnssecGrant"
+      actions   = ["kms:CreateGrant"]
+      resources = ["*"]
+
+      principals {
+        type        = "Service"
+        identifiers = ["dnssec-route53.${local.dns_suffix}"]
+      }
+
+      condition {
+        test     = "Bool"
+        variable = "kms:GrantIsForAWSResource"
+        values   = ["true"]
+      }
+
+      dynamic "condition" {
+        for_each = var.route53_dnssec_sources
+
+        content {
+          test     = "StringEquals"
+          variable = "aws:SourceAccount"
+          values   = try(condition.value.account_ids, [local.account_id])
+        }
+      }
+
+      dynamic "condition" {
+        for_each = var.route53_dnssec_sources
+
+        content {
+          test     = "ArnLike"
+          variable = "aws:SourceArn"
+          values   = [try(condition.value.hosted_zone_arn, "arn:${local.partition}:route53:::hostedzone/*")]
+        }
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.key_statements
+
+    content {
+      sid           = try(statement.value.sid, null)
+      actions       = try(statement.value.actions, null)
+      not_actions   = try(statement.value.not_actions, null)
+      effect        = try(statement.value.effect, null)
+      resources     = try(statement.value.resources, null)
+      not_resources = try(statement.value.not_resources, null)
+
+      dynamic "principals" {
+        for_each = try(statement.value.principals, [])
+
+        content {
+          type        = principals.value.type
+          identifiers = principals.value.identifiers
+        }
+      }
+
+      dynamic "not_principals" {
+        for_each = try(statement.value.not_principals, [])
+
+        content {
+          type        = not_principals.value.type
+          identifiers = not_principals.value.identifiers
+        }
+      }
+
+      dynamic "condition" {
+        for_each = try(statement.value.conditions, [])
+
+        content {
+          test     = condition.value.test
+          values   = condition.value.values
+          variable = condition.value.variable
+        }
+      }
     }
   }
 }
@@ -285,7 +482,7 @@ resource "aws_kms_alias" "this" {
 
   name          = var.aliases_use_name_prefix ? null : "alias/${each.value.name}"
   name_prefix   = var.aliases_use_name_prefix ? "alias/${each.value.name}-" : null
-  target_key_id = var.create_external ? aws_kms_external_key.this[0].id : aws_kms_key.this[0].key_id
+  target_key_id = try(aws_kms_key.this[0].key_id, aws_kms_external_key.this[0].id, aws_kms_replica_key.this[0].key_id, aws_kms_replica_external_key.this[0].key_id)
 }
 
 ################################################################################
@@ -296,7 +493,7 @@ resource "aws_kms_grant" "this" {
   for_each = { for k, v in var.grants : k => v if var.create }
 
   name              = try(each.value.name, each.key)
-  key_id            = var.create_external ? aws_kms_external_key.this[0].id : aws_kms_key.this[0].key_id
+  key_id            = try(aws_kms_key.this[0].key_id, aws_kms_external_key.this[0].id, aws_kms_replica_key.this[0].key_id, aws_kms_replica_external_key.this[0].key_id)
   grantee_principal = each.value.grantee_principal
   operations        = each.value.operations
 

--- a/aws-kms/outputs.tf
+++ b/aws-kms/outputs.tf
@@ -4,32 +4,32 @@
 
 output "key_arn" {
   description = "The Amazon Resource Name (ARN) of the key"
-  value       = try(aws_kms_key.this[0].arn, aws_kms_external_key.this[0].arn, null)
+  value       = try(aws_kms_key.this[0].arn, aws_kms_external_key.this[0].arn, aws_kms_replica_key.this[0].arn, aws_kms_replica_external_key.this[0].arn, null)
 }
 
 output "key_id" {
   description = "The globally unique identifier for the key"
-  value       = try(aws_kms_key.this[0].key_id, aws_kms_external_key.this[0].id, null)
+  value       = try(aws_kms_key.this[0].key_id, aws_kms_external_key.this[0].id, aws_kms_replica_key.this[0].key_id, aws_kms_replica_external_key.this[0].key_id, null)
 }
 
 output "key_policy" {
   description = "The IAM resource policy set on the key"
-  value       = try(aws_kms_key.this[0].policy, aws_kms_external_key.this[0].policy, null)
+  value       = try(aws_kms_key.this[0].policy, aws_kms_external_key.this[0].policy, aws_kms_replica_key.this[0].policy, aws_kms_replica_external_key.this[0].policy, null)
 }
 
 output "external_key_expiration_model" {
   description = "Whether the key material expires. Empty when pending key material import, otherwise `KEY_MATERIAL_EXPIRES` or `KEY_MATERIAL_DOES_NOT_EXPIRE`"
-  value       = try(aws_kms_external_key.this[0].expiration_model, null)
+  value       = try(aws_kms_external_key.this[0].expiration_model, aws_kms_replica_external_key.this[0].expiration_model, null)
 }
 
 output "external_key_state" {
   description = "The state of the CMK"
-  value       = try(aws_kms_external_key.this[0].key_state, null)
+  value       = try(aws_kms_external_key.this[0].key_state, aws_kms_replica_external_key.this[0].key_state, null)
 }
 
 output "external_key_usage" {
   description = "The cryptographic operations for which you can use the CMK"
-  value       = try(aws_kms_external_key.this[0].key_usage, null)
+  value       = try(aws_kms_external_key.this[0].key_usage, aws_kms_replica_external_key.this[0].key_usage, null)
 }
 
 ################################################################################
@@ -55,6 +55,6 @@ output "grants" {
 ################################################################################
 
 output "public_key" {
-  value = try(data.aws_kms_public_key.by_id, null)
+  value     = try(data.aws_kms_public_key.by_id, null)
   sensitive = true
 }

--- a/aws-kms/variables.tf
+++ b/aws-kms/variables.tf
@@ -32,6 +32,12 @@ variable "customer_master_key_spec" {
   default     = null
 }
 
+variable "custom_key_store_id" {
+  description = "ID of the KMS Custom Key Store where the key will be stored instead of KMS (eg CloudHSM)."
+  type        = string
+  default     = null
+}
+
 variable "deletion_window_in_days" {
   description = "The waiting period, specified in number of days. After the waiting period ends, AWS KMS deletes the KMS key. If you specify a value, it must be between `7` and `30`, inclusive. If you do not specify a value, it defaults to `30`"
   type        = number
@@ -116,6 +122,12 @@ variable "key_service_users" {
   default     = []
 }
 
+variable "key_service_roles_for_autoscaling" {
+  description = "A list of IAM ARNs for [AWSServiceRoleForAutoScaling roles](https://docs.aws.amazon.com/autoscaling/ec2/userguide/key-policy-requirements-EBS-encryption.html#policy-example-cmk-access)"
+  type        = list(string)
+  default     = []
+}
+
 variable "key_symmetric_encryption_users" {
   description = "A list of IAM ARNs for [key symmetric encryption users](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-users-crypto)"
   type        = list(string)
@@ -146,6 +158,12 @@ variable "key_services" {
   default     = []
 }
 
+variable "key_statements" {
+  description = "A map of IAM policy [statements](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#statement) for custom permission usage"
+  type        = any
+  default     = {}
+}
+
 variable "source_policy_documents" {
   description = "List of IAM policy documents that are merged together into the exported document. Statements must have unique `sid`s"
   type        = list(string)
@@ -156,6 +174,50 @@ variable "override_policy_documents" {
   description = "List of IAM policy documents that are merged together into the exported document. In merging, statements with non-blank `sid`s will override statements with the same `sid`"
   type        = list(string)
   default     = []
+}
+
+variable "enable_route53_dnssec" {
+  description = "Determines whether the KMS policy used for Route53 DNSSEC signing is enabled"
+  type        = bool
+  default     = false
+}
+
+variable "route53_dnssec_sources" {
+  description = "A list of maps containing `account_ids` and Route53 `hosted_zone_arn` that will be allowed to sign DNSSEC records"
+  type        = list(any)
+  default     = []
+}
+
+################################################################################
+# Replica Key
+################################################################################
+
+variable "create_replica" {
+  description = "Determines whether a replica standard CMK will be created (AWS provided material)"
+  type        = bool
+  default     = false
+}
+
+variable "primary_key_arn" {
+  description = "The primary key arn of a multi-region replica key"
+  type        = string
+  default     = null
+}
+
+################################################################################
+# Replica External Key
+################################################################################
+
+variable "create_replica_external" {
+  description = "Determines whether a replica external CMK will be created (externally provided material)"
+  type        = bool
+  default     = false
+}
+
+variable "primary_external_key_arn" {
+  description = "The primary external key arn of a multi-region replica external key"
+  type        = string
+  default     = null
 }
 
 ################################################################################
@@ -189,7 +251,6 @@ variable "grants" {
   type        = any
   default     = {}
 }
-
 
 variable "create_public_key" {
   description = "Determines whether output public key of kms"

--- a/aws-kms/versions.tf
+++ b/aws-kms/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0, < 1.6.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.72"
+      version = ">= 4.33"
     }
   }
 }


### PR DESCRIPTION
`var.key_statements` allows us to add custom key policy statements without needing to
fork from the upstream as often.

