### PR TITLE
fix: remove required version upper limits

### DIFF
--- a/modules/aws-eks-rancher-importer/versions.tf
+++ b/modules/aws-eks-rancher-importer/versions.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.0"
+
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/aws-eks-rancher-joiner/versions.tf
+++ b/modules/aws-eks-rancher-joiner/versions.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 0.13.1"
+
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/aws-kms/versions.tf
+++ b/modules/aws-kms/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0, < 1.6.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/modules/aws-secrets-manager/versions.tf
+++ b/modules/aws-secrets-manager/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.0"
 
   required_providers {
     aws = ">= 2.67.0"

--- a/modules/metadata/versions.tf
+++ b/modules/metadata/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 1.5.0"
+  required_version = ">= 1.5.0"
 }


### PR DESCRIPTION
These upper limits were placed due to terraform's license changes, not required anymore.

Also added a few missing `required_version` attributes
