### PR TITLE
feat: use aws_subnets instead of aws_subnet_ids

### DIFF
--- a/modules/aws-elasticache-redis/README.md
+++ b/modules/aws-elasticache-redis/README.md
@@ -193,7 +193,7 @@ No modules.
 | [aws_security_group_rule.redis_ingress_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.redis_ingress_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [random_id.redis_pg](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [aws_subnet_ids.private_subnets_with_cache_tag](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnets.private_subnets_with_cache_tag](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 
 ## Inputs
 

--- a/modules/aws-elasticache-redis/main.tf
+++ b/modules/aws-elasticache-redis/main.tf
@@ -86,8 +86,11 @@ resource "aws_elasticache_parameter_group" "redis" {
   tags = var.tags
 }
 
-data "aws_subnet_ids" "private_subnets_with_cache_tag" {
-  vpc_id = var.vpc_id
+data "aws_subnets" "private_subnets_with_cache_tag" {
+  filter {
+    name   = "vpc-id"
+    values = [var.vpc_id]
+  }
   tags = {
     Name = var.subnet_id_names
   }
@@ -95,7 +98,7 @@ data "aws_subnet_ids" "private_subnets_with_cache_tag" {
 
 resource "aws_elasticache_subnet_group" "redis" {
   name        = var.global_replication_group_id == null ? "${var.name_prefix}-redis-sg" : "${var.name_prefix}-redis-sg-replica"
-  subnet_ids  = data.aws_subnet_ids.private_subnets_with_cache_tag.ids
+  subnet_ids  = data.aws_subnets.private_subnets_with_cache_tag.ids
   description = var.description
 
   tags = var.tags

--- a/modules/aws-elasticache-redis/versions.tf
+++ b/modules/aws-elasticache-redis/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.0.11"
 
   required_providers {
-    aws    = ">= 4.8.0, < 5.0.0"
+    aws    = ">= 4.8.0, < 7.0.0"
     random = ">= 3.3.2, < 4.0.0"
   }
 }


### PR DESCRIPTION
For compatibility with newer aws provider