### PR TITLE
feat(aws-waf): add WebACL association resource for ALB/resource binding

### DIFF
--- a/modules/aws-waf/main.tf
+++ b/modules/aws-waf/main.tf
@@ -2146,3 +2146,13 @@ resource "aws_wafv2_web_acl_logging_configuration" "main" {
   }
 }
 
+
+###############################################################################
+# WebACL Association
+###############################################################################
+
+resource "aws_wafv2_web_acl_association" "this" {
+  for_each     = toset(var.association_resource_arns)
+  resource_arn = each.value
+  web_acl_arn  = aws_wafv2_web_acl.waf_acl[0].arn
+}

--- a/modules/aws-waf/outputs.tf
+++ b/modules/aws-waf/outputs.tf
@@ -3,6 +3,11 @@ output "web_acl_arn" {
   value       = aws_wafv2_web_acl.waf_acl[0].arn
 }
 
+output "web_acl_id" {
+  description = "ID of the Waf WebACL"
+  value       = aws_wafv2_web_acl.waf_acl[0].id
+}
+
 output "web_acl_capacity" {
   description = "Web ACL capacity units (WCUs) currently being used by this web ACL"
   value       = aws_wafv2_web_acl.waf_acl[0].capacity

--- a/modules/aws-waf/variables.tf
+++ b/modules/aws-waf/variables.tf
@@ -117,3 +117,9 @@ variable "custom_response_bodies" {
   description = "Custom response bodies to be referenced on a per rule basis. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#custom-response-body"
   default     = []
 }
+
+variable "association_resource_arns" {
+  type        = list(string)
+  description = "List of ARNs of the resources (ALB, API Gateway, etc.) to associate with the WebACL."
+  default     = []
+}


### PR DESCRIPTION
- Add aws_wafv2_web_acl_association resource with for_each support
- Add association_resource_arns variable (list of ALB/API GW ARNs)
- Add web_acl_id output
- Enables attaching WAF WebACL to ALB directly from the module

## Summary

Add `aws_wafv2_web_acl_association` resource to the `aws-waf` module, enabling direct attachment of a WAF WebACL to ALB/API Gateway resources from within the module.

## Changes

- **`modules/aws-waf/variables.tf`**: Add `association_resource_arns` variable (list of resource ARNs)
- **`modules/aws-waf/main.tf`**: Add `aws_wafv2_web_acl_association` resource with `for_each` support
- **`modules/aws-waf/outputs.tf`**: Add `web_acl_id` output