### PR TITLE
feat(aws-waf): wire custom_response_bodies into web ACL resource

### DIFF
--- a/modules/aws-waf/main.tf
+++ b/modules/aws-waf/main.tf
@@ -2082,6 +2082,15 @@ resource "aws_wafv2_web_acl" "waf_acl" {
     }
   }
 
+  dynamic "custom_response_body" {
+    for_each = var.custom_response_bodies
+    content {
+      key          = custom_response_body.value.key
+      content      = custom_response_body.value.content
+      content_type = custom_response_body.value.content_type
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = var.cw_metrics
     metric_name                = var.metric_name


### PR DESCRIPTION
## What
Render the existing `custom_response_bodies` variable as `custom_response_body` blocks on the `aws_wafv2_web_acl.waf_acl` resource.

## Why
The variable was declared but never wired into the resource, so web-ACL-level custom response bodies (referenced by a rule's `custom_response.custom_response_body_key`) could not be managed in Terraform.

## Notes
- Purely additive; `custom_response_bodies` defaults to `[]`, so existing callers are unaffected.
- `custom_response_body` is a set server-side; list order is irrelevant.
- Verified via downstream `terragrunt plan` in platform-truid preprod & prod: **0 resource changes** (exact match to live).