### PR TITLE
feat: support optional ALB tags and nginx controller pod labels

### DIFF
--- a/modules/aws-eks-addons/main.tf
+++ b/modules/aws-eks-addons/main.tf
@@ -83,6 +83,12 @@ resource "helm_release" "ingress_nginx" {
   version          = var.nginx_version
   create_namespace = true
 
+  values = length(var.nginx_controller_pod_labels) > 0 ? [yamlencode({
+    controller = {
+      podLabels = var.nginx_controller_pod_labels
+    }
+  })] : []
+
   set {
     name  = "controller.service.type"
     value = "NodePort"
@@ -144,7 +150,7 @@ resource "kubernetes_annotations" "alb_ingress_connect_nginx_annotation" {
     name      = var.connect_hostnames_from_alb_ing_prefix != "" ? "${var.connect_hostnames_from_alb_ing_prefix}-nginx" : "ing-nginx"
     namespace = "ingress-nginx"
   }
-  annotations = {
+  annotations = merge({
     "alb.ingress.kubernetes.io/load-balancer-name" = var.loadbalancer_name
     "alb.ingress.kubernetes.io/certificate-arn"    = var.acm_certificate_arn
     "alb.ingress.kubernetes.io/wafv2-acl-arn"      = var.waf_acl_arn
@@ -154,7 +160,9 @@ resource "kubernetes_annotations" "alb_ingress_connect_nginx_annotation" {
     "alb.ingress.kubernetes.io/ssl-redirect"       = "443"
     "alb.ingress.kubernetes.io/listen-ports"       = "[{\"HTTP\": 80}, {\"HTTPS\": 443}]"
     "alb.ingress.kubernetes.io/healthcheck-path"   = "/healthz"
-  }
+    }, length(var.alb_tags) > 0 ? {
+    "alb.ingress.kubernetes.io/tags" = join(",", [for k, v in var.alb_tags : "${k}=${v}"])
+  } : {})
   depends_on = [
     kubernetes_ingress_v1.alb_ingress_connect_nginx
   ]
@@ -209,7 +217,7 @@ resource "kubernetes_annotations" "alb_ingress_connect_internal_nginx_annotation
     name      = var.connect_hostnames_from_alb_internal_ing_prefix != "" ? "${var.connect_hostnames_from_alb_internal_ing_prefix}-nginx-internal" : "ing-nginx-internal"
     namespace = "ingress-nginx"
   }
-  annotations = {
+  annotations = merge({
     "alb.ingress.kubernetes.io/load-balancer-name" = var.internal_loadbalancer_name
     "alb.ingress.kubernetes.io/certificate-arn"    = var.acm_certificate_arn
     "alb.ingress.kubernetes.io/wafv2-acl-arn"      = var.internal_waf_acl_arn
@@ -219,7 +227,9 @@ resource "kubernetes_annotations" "alb_ingress_connect_internal_nginx_annotation
     "alb.ingress.kubernetes.io/ssl-redirect"       = "443"
     "alb.ingress.kubernetes.io/listen-ports"       = "[{\"HTTP\": 80}, {\"HTTPS\": 443}]"
     "alb.ingress.kubernetes.io/healthcheck-path"   = "/healthz"
-  }
+    }, length(var.alb_tags) > 0 ? {
+    "alb.ingress.kubernetes.io/tags" = join(",", [for k, v in var.alb_tags : "${k}=${v}"])
+  } : {})
   depends_on = [
     kubernetes_ingress_v1.alb_ingress_connect_nginx_internal
   ]

--- a/modules/aws-eks-addons/variables.tf
+++ b/modules/aws-eks-addons/variables.tf
@@ -569,3 +569,15 @@ variable "notification_slack_token" {
   default     = ""
   description = "Value of the Slack Token for ArgoCD Notification"
 }
+
+variable "alb_tags" {
+  description = "Extra AWS tags applied to the ALBs created for the nginx ingress connectors. Rendered into the alb.ingress.kubernetes.io/tags annotation on both the external and internal connector ingresses. Empty by default (no extra tags)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "nginx_controller_pod_labels" {
+  description = "Extra pod labels applied to the ingress-nginx controller pods (set as controller.podLabels in the ingress-nginx Helm release). Empty by default (no extra labels)."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary

Add two optional map variables to the `aws-eks-addons` module that let consumers attach arbitrary tags to the managed ALBs and arbitrary pod labels to the ingress-nginx controller. Both are opt-in and default to empty, so current behavior is unchanged for existing consumers.

## Motivation

The module provisions the external/internal ALBs (via the nginx connector ingresses) and the ingress-nginx controller, but there was **no way to attach custom tags/labels** to them. Consumers that need resource-level metadata on this shared ingress infrastructure — e.g. for cost allocation, ownership, or governance/reporting — had no supported input and would otherwise have to fork the module or patch resources out-of-band.

## Changes

**New variables** (`variables.tf`):

| Variable | Type | Default | Purpose |
|---|---|---|---|
| `alb_tags` | `map(string)` | `{}` | Extra AWS tags for the ALBs created by the nginx connector ingresses |
| `nginx_controller_pod_labels` | `map(string)` | `{}` | Extra pod labels for the ingress-nginx controller pods |

**Wiring** (`main.tf`):

- `alb_tags` is rendered into the `alb.ingress.kubernetes.io/tags` annotation on **both** the external and internal connector ingresses (`kubernetes_annotations.alb_ingress_connect_nginx_annotation` and `...internal...`). The AWS Load Balancer Controller then propagates these tags to the ALB and its dependent resources (security group, listeners, listener rules, target groups).
  - Rendered as the controller-expected string form: `join(",", [for k, v in var.alb_tags : "${k}=${v}"])`.
  - Added via `merge(<existing annotations>, length(var.alb_tags) > 0 ? { "alb.ingress.kubernetes.io/tags" = ... } : {})` so the key is only present when the map is non-empty.
- `nginx_controller_pod_labels` is applied as `controller.podLabels` on the `ingress-nginx` Helm release, via a `values` block using `yamlencode` (only emitted when the map is non-empty).

## Backward compatibility

- Both variables default to `{}`.
- When empty, `merge(..., {})` yields the exact same annotation set as before, and the Helm `values` list stays empty — **no diff / no behavior change** for existing consumers.
- No existing variables, outputs, or resource addresses change.

## Usage example

```hcl
inputs = {
  # ...existing addons inputs...

  alb_tags = {
    Environment = "dev"
    Service     = "Ingress"
  }

  nginx_controller_pod_labels = {
    Name        = "ingress-nginx-controller"
    Environment = "dev"
    Service     = "Ingress"
  }
}
```

## Notes

- Tag/label **values** should not contain `,` or `=`, since ALB tags are encoded as a comma-separated `key=value` string in the annotation.
- Applying `nginx_controller_pod_labels` updates the Helm release and rolls the controller pods (new pod template); schedule during a low-traffic window if needed. `alb_tags` is a metadata-only annotation change with no LB recreation.
