### PR TITLE
feat(aws-cloudfront): allow overriding the OAI bucket policy

### DIFF
--- a/modules/aws-cloudfront/main.tf
+++ b/modules/aws-cloudfront/main.tf
@@ -85,7 +85,12 @@ resource "aws_s3_bucket_policy" "s3_policy" {
   provider = aws.ireland
   for_each = local.create_origin_access_identity && var.create_s3_bucket ? var.origin_access_identities : {}
   bucket   = aws_s3_bucket.this[0].id
-  policy   = jsonencode(
+  # `bucket_policy_override` takes the rendered policy verbatim. It exists for buckets whose live policy
+  # predates this module's shape: adopting them otherwise forces an in-place policy rewrite on the first
+  # apply, which is a real change to a live access control even when the statements are equivalent.
+  # Prefer the generated policy; set the override only to hold an existing policy steady, and drop it once
+  # the bucket has been reconciled.
+  policy   = var.bucket_policy_override != null ? var.bucket_policy_override : jsonencode(
 {
     Version = "2008-10-17",
     Id      = "PolicyForCloudFrontPrivateContent",

--- a/modules/aws-cloudfront/variables.tf
+++ b/modules/aws-cloudfront/variables.tf
@@ -265,6 +265,18 @@ variable "bucket_policy_resources" {
   type        = list(any)
 }
 
+variable "bucket_policy_override" {
+  description = <<-EOT
+    Optional raw JSON used verbatim as the origin-access-identity bucket policy, bypassing the generated one.
+    Intended for adopting a bucket whose live policy predates this module's shape, where the generated policy
+    would otherwise rewrite a live access control on first apply (e.g. a statement whose Resource is a bare
+    string rather than a list, or a duplicate legacy statement). Leave null to use the generated policy;
+    remove the override once the bucket has been reconciled.
+  EOT
+  default     = null
+  type        = string
+}
+
 variable "cors_rule" {
   description = "List of maps containing rules for Cross-Origin Resource Sharing."
   type        = any


### PR DESCRIPTION
Adds an optional escape hatch for adopting S3 buckets whose **live** policy predates this module's generated shape.

## Problem

Bringing an existing bucket under this module forces an in-place policy rewrite on the first apply. The statements are equivalent, but it is still a write to a live access control — and the caller currently has no way to avoid it: `bucket_policy_resources` feeds **both** the OAI statement and `AllowSSLRequestsOnly`, so it cannot render one as a bare string and the other as a two-element list.

Two shapes seen in real prod buckets that the generated policy does not reproduce:

- an OAI statement whose `Resource` is a bare **string** rather than a single-element list
- a **duplicate** statement granting the same origin access identity the same access (`Sid` `"1"` and `"2"`)

Both plan as `~ update in-place` on a resource nobody intended to change.

## Change

```diff
-  policy   = jsonencode(
+  policy   = var.bucket_policy_override != null ? var.bucket_policy_override : jsonencode(
```

plus the new `bucket_policy_override` variable (`type = string`, `default = null`).

## Backward compatibility

**No existing caller is affected.** The default is `null`, and the expression then evaluates to exactly the previous `jsonencode(...)` — byte-identical output, so repointing a stack at the new version yields a zero-diff plan.

Verified before opening this PR:

- the `module/aws-cloudfront/v1.1.0` tag and `main` are **byte-identical** for `main.tf`, `variables.tf`, `outputs.tf` and `versions.tf`, so a release cut from this branch contains only this change
- `terraform validate` reports the same pre-existing provider-alias errors with and without the change (the module's `aws.ireland` / `aws.shared_infra` aliases can only be supplied by a caller), i.e. no new error is introduced
- `terraform fmt` differences in these two files are pre-existing and were left untouched

## Intent

This is deliberately documented as an **adoption escape hatch**, not a general-purpose knob: the variable description says to prefer the generated policy and to remove the override once the bucket has been reconciled. Pinning the policy also freezes it — a caller using the override will not pick up future improvements to the generated form, and it hardcodes the OAI id rather than referencing the module's own resource.
