### PR TITLE
feat(aws-waf,aws-shield): add Anti-DDoS rule overrides + Shield subscription

### DIFF
--- a/modules/aws-shield/main.tf
+++ b/modules/aws-shield/main.tf
@@ -1,3 +1,15 @@
+# Account-level Shield Advanced subscription. This is a 1-year commitment
+# billed monthly — it can't be cleanly torn down by Terraform (auto-renew
+# can only be disabled in the last 30 days of the term; otherwise AWS
+# Support has to be contacted), hence skip_destroy. Off by default: enable
+# it explicitly per account once that account's commercial sign-off is in.
+resource "aws_shield_subscription" "this" {
+  count = var.enable_subscription ? 1 : 0
+
+  auto_renew   = "ENABLED"
+  skip_destroy = true
+}
+
 resource "aws_shield_protection" "shield" {
   for_each     = { for k, v in var.name_resource_arn_map : k => v if !lookup(v, "cross_account_shield", false) }
   name         = each.key

--- a/modules/aws-shield/variables.tf
+++ b/modules/aws-shield/variables.tf
@@ -1,3 +1,9 @@
+variable "enable_subscription" {
+  type        = bool
+  description = "Whether to enable this account's AWS Shield Advanced subscription (1-year commitment, billed monthly). Leave false until commercial sign-off for this account is confirmed."
+  default     = false
+}
+
 variable "name_resource_arn_map" {
   type        = any
   description = "A map of names and ARNs of resources to be protected. The name will be used as the name of the resource in the AWS console."

--- a/modules/aws-shield/versions.tf
+++ b/modules/aws-shield/versions.tf
@@ -2,8 +2,11 @@ terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4.22"
+      source = "hashicorp/aws"
+      # aws_shield_subscription (new in this module) requires >= 5.60.0
+      # (hashicorp/terraform-provider-aws PR #37637) — bumped from 4.22,
+      # which predates that resource and would fail to plan it.
+      version = ">= 5.60.0"
     }
   }
 }

--- a/modules/aws-waf/main.tf
+++ b/modules/aws-waf/main.tf
@@ -96,6 +96,64 @@ resource "aws_wafv2_web_acl" "waf_acl" {
             vendor_name = lookup(managed_rule_group_statement.value, "vendor_name", "AWS")
             version     = lookup(managed_rule_group_statement.value, "version", null)
 
+            # Per-rule action overrides for rules inside this managed rule group
+            # (e.g. forcing AWSManagedRulesAntiDDoSRuleSet's ChallengeAllDuringEvent/
+            # ChallengeDDoSRequests/DDoSRequests to Count during initial rollout).
+            # Shape: [{ name = "RuleName", action_to_use = "count" }, ...]
+            dynamic "rule_action_override" {
+              for_each = lookup(managed_rule_group_statement.value, "rule_action_override", [])
+              content {
+                name = lookup(rule_action_override.value, "name")
+
+                action_to_use {
+                  dynamic "allow" {
+                    for_each = lookup(rule_action_override.value, "action_to_use", null) == "allow" ? [1] : []
+                    content {}
+                  }
+                  dynamic "block" {
+                    for_each = lookup(rule_action_override.value, "action_to_use", null) == "block" ? [1] : []
+                    content {}
+                  }
+                  dynamic "count" {
+                    for_each = lookup(rule_action_override.value, "action_to_use", null) == "count" ? [1] : []
+                    content {}
+                  }
+                  dynamic "captcha" {
+                    for_each = lookup(rule_action_override.value, "action_to_use", null) == "captcha" ? [1] : []
+                    content {}
+                  }
+                  dynamic "challenge" {
+                    for_each = lookup(rule_action_override.value, "action_to_use", null) == "challenge" ? [1] : []
+                    content {}
+                  }
+                }
+              }
+            }
+
+            # Rule-group-specific configuration. Currently only the Anti-DDoS
+            # rule set's tuning knobs are wired up (sensitivity_to_block,
+            # client_side_action_config). Shape:
+            # { aws_managed_rules_anti_ddos_rule_set = { sensitivity_to_block = "LOW",
+            #     client_side_action_config = { usage_of_action = "ENABLED", sensitivity = "HIGH" } } }
+            dynamic "managed_rule_group_configs" {
+              for_each = length(lookup(managed_rule_group_statement.value, "managed_rule_group_configs", {})) == 0 ? [] : [lookup(managed_rule_group_statement.value, "managed_rule_group_configs", {})]
+              content {
+                dynamic "aws_managed_rules_anti_ddos_rule_set" {
+                  for_each = length(lookup(managed_rule_group_configs.value, "aws_managed_rules_anti_ddos_rule_set", {})) == 0 ? [] : [lookup(managed_rule_group_configs.value, "aws_managed_rules_anti_ddos_rule_set", {})]
+                  content {
+                    sensitivity_to_block = lookup(aws_managed_rules_anti_ddos_rule_set.value, "sensitivity_to_block", "LOW")
+
+                    client_side_action_config {
+                      challenge {
+                        usage_of_action = lookup(lookup(aws_managed_rules_anti_ddos_rule_set.value, "client_side_action_config", {}), "usage_of_action", "ENABLED")
+                        sensitivity     = lookup(lookup(aws_managed_rules_anti_ddos_rule_set.value, "client_side_action_config", {}), "sensitivity", "HIGH")
+                      }
+                    }
+                  }
+                }
+              }
+            }
+
             dynamic "scope_down_statement" {
               for_each = length(lookup(managed_rule_group_statement.value, "scope_down_statement", {})) == 0 ? [] : [lookup(managed_rule_group_statement.value, "scope_down_statement", {})]
               content {

--- a/modules/aws-waf/main.tf
+++ b/modules/aws-waf/main.tf
@@ -2130,7 +2130,7 @@ resource "aws_wafv2_web_acl" "waf_acl" {
       }
 
       dynamic "visibility_config" {
-        for_each = length(lookup(rule.value, "visibility_config")) == 0 ? [] : [lookup(rule.value, "visibility_config", {})]
+        for_each = length(lookup(rule.value, "visibility_config", {})) == 0 ? [] : [lookup(rule.value, "visibility_config", {})]
         content {
           cloudwatch_metrics_enabled = lookup(visibility_config.value, "cloudwatch_metrics_enabled", true)
           metric_name                = lookup(visibility_config.value, "metric_name", "${var.waf_web_acl_name}-default-rule-metric-name")

--- a/modules/aws-waf/versions.tf
+++ b/modules/aws-waf/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      # rule_action_override + managed_rule_group_configs.aws_managed_rules_anti_ddos_rule_set
+      # require v6.1.0 (https://github.com/hashicorp/terraform-provider-aws/blob/v6.1.0/CHANGELOG.md,
+      # PR #43149). Callers not using those fields still work on older 6.x,
+      # but pinning here prevents a stale lock file from silently resolving
+      # a provider that predates this schema.
+      version = ">= 6.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Two small, purely additive changes to `aws-waf` and `aws-shield` to support AWS's newer Anti-DDoS Managed Rule Group (`AWSManagedRulesAntiDDoSRuleSet`) and Shield Advanced subscriptions.

This started as a client-specific module written for an engagement's rate-limit / L7 DDoS protection rollout. Partway through, it became clear `aws-waf` and `aws-shield` already covered most of what was needed, so instead of maintaining a duplicate module, the missing pieces are added here.

## Changes

**`aws-waf`:**
- Two new optional fields inside a rule's `managed_rule_group_statement`:
  - `rule_action_override` — per-rule action overrides for individual rules inside a managed rule group (e.g. forcing `AWSManagedRulesAntiDDoSRuleSet`'s `DDoSRequests` rule to `Count` during an initial rollout instead of its default `Block`).
  - `managed_rule_group_configs.aws_managed_rules_anti_ddos_rule_set` — the Anti-DDoS rule set's own tuning knobs (`sensitivity_to_block`, `client_side_action_config`).
- Added `versions.tf`, pinning the provider floor to `>= 6.1.0` — this schema landed in that version of `hashicorp/terraform-provider-aws` (PR #43149); an older provider would reject it outright.

**`aws-shield`:**
- New `aws_shield_subscription` resource, gated behind `enable_subscription` (default `false`) — Shield Advanced is a 1-year commitment billed monthly, so this stays opt-in per account until commercial sign-off is confirmed. `skip_destroy = true`, since Terraform can't cleanly tear this down (auto-renew can only be disabled in the last 30 days of the term; otherwise it needs an AWS Support case).
- Bumped the provider floor from `>= 4.22` to `>= 5.60.0` — `aws_shield_subscription` was added in that version (PR #37637).

## Fix included

Also fixes a pre-existing bug found while testing: a rule's `visibility_config` used a 2-arg `lookup()` with no default, which hard-errors at `plan` time (not caught by `validate`) for any rule that doesn't set it — including the new Anti-DDoS rule this PR adds. One-line fix, re-verified with a full local `plan`.

## Backward compatibility

**No existing consumer is affected.** This repo tags each module independently (`module/aws-waf/vX.Y.Z`, `module/aws-shield/vX.Y.Z`), so anything pinned to an existing tag keeps resolving to the exact same code it does today — nothing here touches those tags. The new fields are optional with empty/false defaults; any existing `rules` entry that doesn't set them behaves identically to before.

One thing worth flagging for whoever eventually adopts the *new* tag this PR produces: the provider floor bump (`aws-shield`: `4.22` → `5.60.0`) means a consumer whose own root `required_providers` pins an older AWS provider will need to raise that pin too, once they choose to move to the new tag. That's a normal, expected part of picking up a new module version — not something that happens automatically or silently.

## Verification

- `terraform validate` **and** a full local `terraform plan` for both modules (fake credentials, no backend, no real AWS account touched) against the real `hashicorp/aws` provider (v6.59.0), using the exact configuration shape a Count-mode Anti-DDoS rollout needs — passed.
- No `terraform plan`/`apply` was run against any real account.

## Context

Driven by a client engagement's DDoS protection rollout requirements. No client-specific values live in this PR — it's generic AWS WAF/Shield capability, reusable by any customer.
