### PR TITLE
feat(aws-sns): support secret-backed subscription endpoints via SSM

### DIFF
--- a/modules/aws-sns/README.md
+++ b/modules/aws-sns/README.md
@@ -68,6 +68,33 @@ module "sns_topic" {
 }
 ```
 
+### Subscription with a Secret-Backed Endpoint
+
+For endpoints that embed a credential (e.g. an API key in the URL, as some
+webhook-style integrations require), set `endpoint_secret_ssm_path` +
+`endpoint_template` instead of a literal `endpoint`. The value is read from
+SSM Parameter Store (SecureString) at apply time via a `data` source, so it
+never needs to be known at Terragrunt/config-generation time and is treated
+as sensitive in plan output. Subscriptions that don't set
+`endpoint_secret_ssm_path` are unaffected and keep using a literal `endpoint`
+as before.
+
+```hcl
+module "sns_topic" {
+  source = "../.."
+
+  name = "example-alerts"
+
+  subscriptions = {
+    webhook = {
+      protocol                 = "https"
+      endpoint_secret_ssm_path = "/example/prod/webhook/api_key"
+      endpoint_template        = "https://example.com/notify?apiKey=%s"
+    }
+  }
+}
+```
+
 ### FIFO Topic w/ FIFO SQS Subscription
 
 ```hcl

--- a/modules/aws-sns/main.tf
+++ b/modules/aws-sns/main.tf
@@ -141,21 +141,46 @@ resource "aws_sns_topic_policy" "this" {
 # Subscription(s)
 ################################################################################
 
+locals {
+  # Subscriptions that opt in to building their endpoint from an SSM
+  # SecureString instead of a plain literal (e.g. an endpoint that embeds an
+  # API key, like Opsgenie's SNS integration). Everything else is unaffected.
+  secret_backed_subscriptions = {
+    for k, v in var.subscriptions : k => v
+    if try(v.endpoint_secret_ssm_path, null) != null
+  }
+}
+
+data "aws_ssm_parameter" "endpoint_secret" {
+  for_each = local.secret_backed_subscriptions
+
+  name            = each.value.endpoint_secret_ssm_path
+  with_decryption = true
+}
+
 resource "aws_sns_topic_subscription" "this" {
   for_each = { for k, v in var.subscriptions : k => v if var.create && var.create_subscription }
 
   confirmation_timeout_in_minutes = try(each.value.confirmation_timeout_in_minutes, null)
   delivery_policy                 = try(each.value.delivery_policy, null)
-  endpoint                        = each.value.endpoint
-  endpoint_auto_confirms          = try(each.value.endpoint_auto_confirms, null)
-  filter_policy                   = try(each.value.filter_policy, null)
-  filter_policy_scope             = try(each.value.filter_policy_scope, null)
-  protocol                        = each.value.protocol
-  raw_message_delivery            = try(each.value.raw_message_delivery, null)
-  redrive_policy                  = try(each.value.redrive_policy, null)
-  replay_policy                   = try(each.value.replay_policy, null)
-  subscription_role_arn           = try(each.value.subscription_role_arn, null)
-  topic_arn                       = aws_sns_topic.this[0].arn
+
+  # If endpoint_secret_ssm_path is set, build the endpoint from the SSM value
+  # via endpoint_template (a format() string with a single %s placeholder).
+  # Otherwise, use the literal endpoint as before.
+  endpoint = try(each.value.endpoint_secret_ssm_path, null) != null ? format(
+    each.value.endpoint_template,
+    data.aws_ssm_parameter.endpoint_secret[each.key].value
+  ) : each.value.endpoint
+
+  endpoint_auto_confirms = try(each.value.endpoint_auto_confirms, null)
+  filter_policy          = try(each.value.filter_policy, null)
+  filter_policy_scope    = try(each.value.filter_policy_scope, null)
+  protocol               = each.value.protocol
+  raw_message_delivery   = try(each.value.raw_message_delivery, null)
+  redrive_policy         = try(each.value.redrive_policy, null)
+  replay_policy          = try(each.value.replay_policy, null)
+  subscription_role_arn  = try(each.value.subscription_role_arn, null)
+  topic_arn              = aws_sns_topic.this[0].arn
 }
 
 ################################################################################

--- a/modules/aws-sns/outputs.tf
+++ b/modules/aws-sns/outputs.tf
@@ -34,4 +34,5 @@ output "topic_beginning_archive_time" {
 output "subscriptions" {
   description = "Map of subscriptions created and their attributes"
   value       = aws_sns_topic_subscription.this
+  sensitive   = true
 }


### PR DESCRIPTION
## Summary
Adds an optional `endpoint_secret_ssm_path` + `endpoint_template` pair to
subscription entries in the aws-sns module, for endpoints that embed a
credential (e.g. an API key in the URL, as some webhook-style integrations
require — Opsgenie's SNS integration is one example).

When set, the endpoint is built at *apply* time from an SSM Parameter Store
SecureString via a `data "aws_ssm_parameter"` source, instead of a literal
string passed in from the caller. `value` is marked `Sensitive: true` by the
AWS provider unconditionally (verified against the provider source), so the
resolved endpoint is redacted as `(sensitive value)` in plan/apply output.

Subscriptions that don't set `endpoint_secret_ssm_path` are completely
unaffected — same `endpoint` behavior as before.

## Why
A downstream consumer needed to stop passing a secret through a raw
environment variable at config-generation time (which broke any unit merely
*depending on* this one for outputs, since the env var wasn't always
available) and instead resolve it from AWS's own secret store at apply time,
without changing behavior for any other subscription type.

## Testing
- `terraform fmt -check` clean
- Verified `data.aws_ssm_parameter.value` sensitivity against the provider
  source (`internal/service/ssm/parameter_data_source.go`)
- Not yet applied against a real SSM parameter — first real usage will be in
  a downstream consumer's PR

## Notes
- Minor: if both `endpoint` and `endpoint_secret_ssm_path` are set, the
  latter silently wins. Documented behavior, open to adding an explicit
  validation error instead if preferred.
