### PR TITLE
feat(aws-waf): add regex_match_statement support

### DIFF
--- a/modules/aws-waf/main.tf
+++ b/modules/aws-waf/main.tf
@@ -820,6 +820,48 @@ resource "aws_wafv2_web_acl" "waf_acl" {
           }
         }
 
+        dynamic "regex_match_statement" {
+          for_each = length(lookup(rule.value, "regex_match_statement", {})) == 0 ? [] : [lookup(rule.value, "regex_match_statement", {})]
+          content {
+            regex_string = lookup(regex_match_statement.value, "regex_string")
+            dynamic "field_to_match" {
+              for_each = length(lookup(regex_match_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(regex_match_statement.value, "field_to_match", {})]
+              content {
+                dynamic "uri_path" {
+                  for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                  content {}
+                }
+                dynamic "all_query_arguments" {
+                  for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                  content {}
+                }
+                dynamic "body" {
+                  for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                  content {}
+                }
+                dynamic "method" {
+                  for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                  content {}
+                }
+                dynamic "query_string" {
+                  for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                  content {}
+                }
+                dynamic "single_header" {
+                  for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                  content {
+                    name = lower(lookup(single_header.value, "name"))
+                  }
+                }
+              }
+            }
+            text_transformation {
+              priority = lookup(regex_match_statement.value, "priority")
+              type     = lookup(regex_match_statement.value, "type")
+            }
+          }
+        }
+
         dynamic "ip_set_reference_statement" {
           for_each = length(lookup(rule.value, "ip_set_reference_statement", {})) == 0 ? [] : [lookup(rule.value, "ip_set_reference_statement", {})]
           content {
@@ -1535,6 +1577,49 @@ resource "aws_wafv2_web_acl" "waf_acl" {
                       fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
                       header_name       = lookup(forwarded_ip_config.value, "header_name")
                     }
+                  }
+                }
+              }
+
+              # NOT regex_match_statement
+              dynamic "regex_match_statement" {
+                for_each = length(lookup(not_statement.value, "regex_match_statement", {})) == 0 ? [] : [lookup(not_statement.value, "regex_match_statement", {})]
+                content {
+                  regex_string = lookup(regex_match_statement.value, "regex_string")
+                  dynamic "field_to_match" {
+                    for_each = length(lookup(regex_match_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(regex_match_statement.value, "field_to_match", {})]
+                    content {
+                      dynamic "uri_path" {
+                        for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                        content {}
+                      }
+                      dynamic "all_query_arguments" {
+                        for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                        content {}
+                      }
+                      dynamic "body" {
+                        for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                        content {}
+                      }
+                      dynamic "method" {
+                        for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                        content {}
+                      }
+                      dynamic "query_string" {
+                        for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                        content {}
+                      }
+                      dynamic "single_header" {
+                        for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                        content {
+                          name = lower(lookup(single_header.value, "name"))
+                        }
+                      }
+                    }
+                  }
+                  text_transformation {
+                    priority = lookup(regex_match_statement.value, "priority")
+                    type     = lookup(regex_match_statement.value, "type")
                   }
                 }
               }


### PR DESCRIPTION
## Summary

Adds `regex_match_statement` support to the `aws-waf` module's `rules` variable — both as a top-level rule statement and nested inside `not_statement`. This is a pure schema-coverage gap fill, not a behavior change: the module already supports several other WAFv2 statement types (`byte_match_statement`, `ip_set_reference_statement`, `managed_rule_group_statement`, `geo_match_statement`, …), but had no support at all for WAFv2's `RegexMatchStatement` (inline `RegexString` matching — distinct from `regex_pattern_set_reference_statement`, which references a separate pattern-set resource and was already supported).

## What changed

`modules/aws-waf/main.tf`:

- **Top-level `regex_match_statement`** — added alongside the existing `byte_match_statement` dynamic block, same shape: `field_to_match` (all the same sub-fields: `uri_path`, `all_query_arguments`, `body`, `method`, `query_string`, `single_header`), `regex_string`, and a single `text_transformation` block (`priority`/`type`), mirroring `byte_match_statement`'s exact structure and conventions.
- **`not_statement` → `regex_match_statement`** — same addition inside the existing `not_statement` block, alongside its other nested statement types (`byte_match_statement`, `geo_match_statement`, `ip_set_reference_statement`, `label_match_statement`, `regex_pattern_set_reference_statement`).

## Why this is safe for existing callers

`rules` is `type = any` — every consumer supplies its own list of rule objects, and each statement type is rendered via a `dynamic` block gated on whether that specific key is present in the rule object (`for_each = length(lookup(rule.value, "regex_match_statement", {})) == 0 ? [] : [...]`). A rule that doesn't include a `regex_match_statement` key renders nothing extra — this is purely additive, in the same pattern every other statement type in this module already follows. No existing caller's rendered configuration changes unless it explicitly opts in by adding this key to one of its rules.

## Validation

- `terraform validate`: clean.
- Local `terraform plan` (fake credentials, `skip_credentials_validation`) instantiating the module with a realistic rule set exercising all three new/existing code paths (top-level `regex_match_statement`, `not_statement → regex_match_statement`, plus the pre-existing `not_statement → ip_set_reference_statement` and `byte_match_statement` cases in the same rule list): clean plan, no errors, all fields (including a base64-decoded `search_string` sanity check on the neighboring `byte_match_statement` rules) render as expected.
- Cross-checked against a real, currently-deployed WAFv2 Web ACL's live rule set (via `aws wafv2 get-web-acl`) containing exactly this statement shape — the generated plan matched the live configuration with zero unexpected diffs on the rules using this new statement type.

## Related

- No ticket reference — this is a generic AWS API schema coverage gap, applicable to any consumer of this module, not tied to a specific engagement.
