### PR TITLE
feat(aws-eks-access-entry): add standalone EKS access entry module

### DIFF
--- a/modules/aws-eks-access-entry/CHANGELOG.md
+++ b/modules/aws-eks-access-entry/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/modules/aws-eks-access-entry/README.md
+++ b/modules/aws-eks-access-entry/README.md
@@ -1,0 +1,140 @@
+# aws-eks-access-entry
+
+Manages EKS **access entries** and **access policy associations** for an existing
+cluster, independently of the module that created the cluster.
+
+`aws-eks` only gained an `access_entries` input in `module/aws-eks/v0.3.0`. Clusters
+still pinned to `v0.2.x` have no way to declare an access entry in code, so their
+entries end up created by hand in the console. This module closes that gap without
+requiring a cluster-module upgrade — the EKS v19 → v20 jump that `v0.3.x` carries is
+a large change to make on a live cluster.
+
+Use it when:
+
+* the cluster is on `aws-eks` `v0.2.x`, or
+* access entries are owned by a different team or lifecycle than the cluster itself.
+
+If the cluster is already on `aws-eks` `v0.3.x`, prefer that module's own
+`access_entries` input — this module takes the same shape, so moving between the two
+is a `terraform state mv`.
+
+## Usage
+
+### Bind a principal to your own RBAC via a Kubernetes group
+
+The AWS-managed access policies are coarse: `AmazonEKSViewPolicy` maps to the built-in
+`view` ClusterRole, which grants `pods/log` and `configmaps`. When that is more than
+you want, place the principal in a Kubernetes group and bind your own ClusterRole to it.
+
+```hcl
+module "eks_access_entry" {
+  source = "git@github.com:kloia/platform-modules.git/?ref=module/aws-eks-access-entry/v0.1.0"
+
+  cluster_name = "my-cluster"
+
+  access_entries = {
+    inventory_readonly = {
+      # IAM Identity Center roles keep their full path here — do not strip it.
+      principal_arn     = "arn:aws:iam::111122223333:role/aws-reserved/sso.amazonaws.com/eu-west-1/AWSReservedSSO_MyPermissionSet_0123456789abcdef"
+      kubernetes_groups = ["platform:inventory-readonly"]
+    }
+  }
+
+  tags = {
+    Environment = "prod"
+    Project     = "platform"
+  }
+}
+```
+
+The `ClusterRole` and `ClusterRoleBinding` for `platform:inventory-readonly` are not
+created here — this module only manages the AWS side of the mapping.
+
+### Associate an AWS-managed access policy
+
+```hcl
+access_entries = {
+  cluster_admin = {
+    principal_arn = "arn:aws:iam::111122223333:role/PlatformAdmin"
+
+    policy_associations = {
+      admin = {
+        policy_arn   = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+        access_scope = { type = "cluster" }
+      }
+    }
+  }
+
+  team_namespace_view = {
+    principal_arn = "arn:aws:iam::111122223333:role/TeamViewer"
+
+    policy_associations = {
+      view = {
+        policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
+        access_scope = {
+          type       = "namespace"
+          namespaces = ["team-a", "team-b"]
+        }
+      }
+    }
+  }
+}
+```
+
+### Node group entries
+
+```hcl
+access_entries = {
+  linux_nodes = {
+    principal_arn = aws_iam_role.node_group.arn
+    type          = "EC2_LINUX"
+  }
+}
+```
+
+`kubernetes_groups` and `user_name` are rejected by the API for the node types and are
+validated against here.
+
+## Notes
+
+* The cluster must have `authentication_mode` set to `API` or `API_AND_CONFIG_MAP`.
+  Access entries are ignored under `CONFIG_MAP`.
+* An access entry with neither `kubernetes_groups` nor `policy_associations` grants
+  nothing. That is a valid state, not an error.
+* Only one access entry may exist per principal ARN per cluster. Importing an entry
+  created by hand is `terraform import module.x.aws_eks_access_entry.this[\"key\"] <cluster>:<principal-arn>`.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|---|---|---|---|:---:|
+| `cluster_name` | Name of the EKS cluster the access entries belong to. | `string` | n/a | yes |
+| `access_entries` | Map of access entries to create, keyed by an arbitrary name. | `map(object)` | `{}` | no |
+| `tags` | Tags applied to every access entry, merged with each entry's own tags. | `map(string)` | `{}` | no |
+
+### `access_entries` object
+
+| Attribute | Description | Type | Default |
+|---|---|---|---|
+| `principal_arn` | IAM role or user ARN. IAM Identity Center roles keep their full path. | `string` | n/a |
+| `type` | `STANDARD`, `EC2`, `EC2_LINUX`, `EC2_WINDOWS`, `FARGATE_LINUX` or `HYBRID_LINUX`. | `string` | `"STANDARD"` |
+| `kubernetes_groups` | Groups the principal is placed in. `STANDARD` only. | `list(string)` | `null` |
+| `user_name` | Kubernetes username for the principal. `STANDARD` only. | `string` | `null` |
+| `tags` | Tags for this entry, merged over `var.tags`. | `map(string)` | `{}` |
+| `policy_associations` | AWS-managed cluster access policies to associate. | `map(object)` | `{}` |
+
+### `policy_associations` object
+
+| Attribute | Description | Type | Default |
+|---|---|---|---|
+| `policy_arn` | `arn:aws:eks::aws:cluster-access-policy/...` | `string` | n/a |
+| `access_scope.type` | `cluster` or `namespace`. | `string` | n/a |
+| `access_scope.namespaces` | Required, non-empty, when `type` is `namespace`. | `list(string)` | `null` |
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `access_entries` | Map of the created access entries, keyed as given in `var.access_entries`. |
+| `access_entry_arns` | Map of access entry key to the ARN of the access entry. |
+| `access_policy_associations` | Map of the created associations, keyed `"<entry key>_<policy key>"`. |

--- a/modules/aws-eks-access-entry/main.tf
+++ b/modules/aws-eks-access-entry/main.tf
@@ -1,0 +1,48 @@
+locals {
+  # One entry per (access entry, policy association) pair, keyed so that two
+  # entries may associate the same policy without colliding. The "<entry>_<policy>"
+  # format matches the aws-eks module, so a consumer that later moves to its
+  # built-in access_entries input can do so with a plain state move.
+  policy_associations = merge([
+    for entry_key, entry in var.access_entries : {
+      for policy_key, policy in entry.policy_associations :
+      "${entry_key}_${policy_key}" => {
+        principal_arn = entry.principal_arn
+        policy_arn    = policy.policy_arn
+        scope_type    = policy.access_scope.type
+        namespaces    = policy.access_scope.namespaces
+      }
+    }
+  ]...)
+}
+
+resource "aws_eks_access_entry" "this" {
+  for_each = var.access_entries
+
+  cluster_name  = var.cluster_name
+  principal_arn = each.value.principal_arn
+  type          = each.value.type
+
+  # Both are rejected by the API for the EC2*/FARGATE/HYBRID node types, which
+  # derive their identity from the node bootstrap instead. var.access_entries
+  # validates that combination rather than silently dropping the values here.
+  kubernetes_groups = each.value.kubernetes_groups
+  user_name         = each.value.user_name
+
+  tags = merge(var.tags, each.value.tags)
+}
+
+resource "aws_eks_access_policy_association" "this" {
+  for_each = local.policy_associations
+
+  cluster_name  = var.cluster_name
+  principal_arn = each.value.principal_arn
+  policy_arn    = each.value.policy_arn
+
+  access_scope {
+    type       = each.value.scope_type
+    namespaces = each.value.namespaces
+  }
+
+  depends_on = [aws_eks_access_entry.this]
+}

--- a/modules/aws-eks-access-entry/outputs.tf
+++ b/modules/aws-eks-access-entry/outputs.tf
@@ -1,0 +1,14 @@
+output "access_entries" {
+  description = "Map of the created access entries, keyed as given in var.access_entries."
+  value       = aws_eks_access_entry.this
+}
+
+output "access_entry_arns" {
+  description = "Map of access entry key to the ARN of the access entry."
+  value       = { for k, v in aws_eks_access_entry.this : k => v.access_entry_arn }
+}
+
+output "access_policy_associations" {
+  description = "Map of the created access policy associations, keyed \"<entry key>_<policy key>\"."
+  value       = aws_eks_access_policy_association.this
+}

--- a/modules/aws-eks-access-entry/variables.tf
+++ b/modules/aws-eks-access-entry/variables.tf
@@ -1,0 +1,78 @@
+variable "cluster_name" {
+  description = "Name of the EKS cluster the access entries belong to."
+  type        = string
+}
+
+variable "access_entries" {
+  description = <<-EOT
+    Map of access entries to create on the cluster, keyed by an arbitrary name.
+
+    Attach Kubernetes permissions in one of two ways:
+      * `kubernetes_groups` — the principal is placed in those groups, and you
+        bind your own ClusterRole/Role to them. Use this when the AWS-managed
+        access policies grant more than you want.
+      * `policy_associations` — associate an AWS-managed cluster access policy
+        (`arn:aws:eks::aws:cluster-access-policy/...`), optionally scoped to
+        namespaces.
+
+    Both may be set on the same entry; the principal receives the union.
+  EOT
+
+  type = map(object({
+    principal_arn     = string
+    type              = optional(string, "STANDARD")
+    kubernetes_groups = optional(list(string))
+    user_name         = optional(string)
+    tags              = optional(map(string), {})
+    policy_associations = optional(map(object({
+      policy_arn = string
+      access_scope = object({
+        type       = string
+        namespaces = optional(list(string))
+      })
+    })), {})
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for entry in var.access_entries :
+      contains(["STANDARD", "EC2", "EC2_LINUX", "EC2_WINDOWS", "FARGATE_LINUX", "HYBRID_LINUX"], entry.type)
+    ])
+    error_message = "access_entries[*].type must be one of STANDARD, EC2, EC2_LINUX, EC2_WINDOWS, FARGATE_LINUX, HYBRID_LINUX."
+  }
+
+  validation {
+    condition = alltrue([
+      for entry in var.access_entries :
+      entry.type == "STANDARD" || (entry.kubernetes_groups == null && entry.user_name == null)
+    ])
+    error_message = "kubernetes_groups and user_name are only valid when type is STANDARD; the node types derive their identity from the node bootstrap."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for entry in var.access_entries : [
+        for policy in entry.policy_associations :
+        contains(["cluster", "namespace"], policy.access_scope.type)
+      ]
+    ]))
+    error_message = "access_scope.type must be either \"cluster\" or \"namespace\"."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for entry in var.access_entries : [
+        for policy in entry.policy_associations :
+        policy.access_scope.type != "namespace" || try(length(policy.access_scope.namespaces), 0) > 0
+      ]
+    ]))
+    error_message = "access_scope.namespaces must be a non-empty list when access_scope.type is \"namespace\"."
+  }
+}
+
+variable "tags" {
+  description = "Tags applied to every access entry, merged with each entry's own tags."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws-eks-access-entry/versions.tf
+++ b/modules/aws-eks-access-entry/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.33"
+    }
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -620,6 +620,15 @@
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
       "prerelease": false
+    },
+    "modules/aws-eks-access-entry": {
+      "component": "aws-eks-access-entry",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "terraform-module",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": false,
+      "draft": false,
+      "prerelease": false
     }
   },
   "separate-pull-requests": true,


### PR DESCRIPTION
## Summary

Adds `modules/aws-eks-access-entry`, managing `aws_eks_access_entry` and
`aws_eks_access_policy_association` for an **existing** cluster, independently of
the module that created it.

## Why

`aws-eks` only gained an `access_entries` input in `module/aws-eks/v0.3.0`. Consumers
still pinned to `v0.2.x` have no way to declare an access entry in code, so entries end
up created by hand in the console and never appear in state.

Upgrading a pinned cluster to `v0.3.x` is the upstream `terraform-aws-modules/eks`
**v19 → v20** jump: 12 variables removed (all `aws_auth_*`, plus `subnet_id_names`),
and node security group defaults change. That is a large change to make on a live
control plane just to add one entry.

This module closes the gap without touching the cluster stack.

## Design

The `access_entries` variable shape deliberately mirrors `aws-eks` v0.3.x's own input,
so a consumer that later upgrades the cluster module can move to it with a
`terraform state mv` rather than a rewrite.

Validates the three combinations the API rejects, which are otherwise only
discoverable at apply time:

- `kubernetes_groups` / `user_name` on the `EC2*` / `FARGATE_LINUX` / `HYBRID_LINUX`
  node types
- an `access_scope.type` outside `cluster` / `namespace`
- a `namespace`-scoped policy association with no namespaces

## Verification

- `terraform fmt -check -recursive` — clean
- `terraform validate` — passes
- `terraform plan` against a real AWS provider with two entries (one group-based, one
  policy-association) — produces the expected 3 resources, nothing applied
- Negative test — both custom validations fire as intended

## Release

Registered in `release-please-config.json` as component `aws-eks-access-entry` with
`bump-minor-pre-major: true`, so the first release is **0.1.0**. Per the existing
`aws-glue` / `aws-athena` precedent, `.release-please-manifest.json` is deliberately
left untouched — release-please writes that entry itself on first release.

On merge this produces tag `aws-eks-access-entry-v0.1.0`, and the `create-module-tag`
job then pushes the orphan-branch tags consumers use:
`module/aws-eks-access-entry/v0`, `/v0.1`, `/v0.1.0`.