### PR TITLE
fix(aws-waf): trigger release-please for #343

### DIFF
--- a/modules/aws-waf/main.tf
+++ b/modules/aws-waf/main.tf
@@ -2308,3 +2308,7 @@ resource "aws_wafv2_web_acl_association" "this" {
   resource_arn = each.value
   web_acl_arn  = aws_wafv2_web_acl.waf_acl[0].arn
 }
+
+# no-op: nudges release-please after #343's squash-merge commit body
+# (nested parentheses in an embedded code snippet) broke its footer parser,
+# so no release PR was cut for this path — see PR #343's merge commit.


### PR DESCRIPTION
Release-please silently failed to cut a release for `modules/aws-waf` after #343 merged — its commit-message parser choked on nested parentheses in an embedded Terraform code snippet inside that PR's body (`length(lookup(...))`), confirmed in the release workflow's own logs:

```
error message: Error: unexpected token '(' at 36:14, valid tokens [)]
```

No functional change here — a clean, simple commit so release-please can detect and cut the missing tag for #343's `regex_match_statement` addition.